### PR TITLE
Add an automatic dark theme

### DIFF
--- a/_sass/jekyll-theme-scpl.scss
+++ b/_sass/jekyll-theme-scpl.scss
@@ -417,4 +417,33 @@ iframe {
 	body {
 		background-color: #29374c;
 	}
+	.realmain {
+		background-color: darken(#29374c, 15%);
+		color: #ccc;
+	}
+
+	.markdown {
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			color: #67bea4;
+		}
+	}
+
+	.markdown a:not(.tryitbtn),
+	a.colorlink {
+		@supports not (background-clip: text) {
+			& {
+				color: #66b0ff;
+			}
+		}
+	}
+
+	textarea, code {
+		background-color: darken(#29374c, 7.5%);
+		color: #ccc;
+	}
 }

--- a/_sass/jekyll-theme-scpl.scss
+++ b/_sass/jekyll-theme-scpl.scss
@@ -43,7 +43,7 @@ body {
 	overflow-x: hidden;
 	overflow-y: scroll;
 	margin: 0;
-	background-color: white;
+	background-color: #29374c;
 	font-family: -apple-system, BlinkMacSystemFont, "Source Sans Pro", Helvetica,
 		Arial, sans-serif;
 }
@@ -414,9 +414,6 @@ iframe {
 }
 
 @media (prefers-color-scheme: dark) {
-	body {
-		background-color: #29374c;
-	}
 	.realmain {
 		background-color: darken(#29374c, 15%);
 		color: #ccc;

--- a/_sass/jekyll-theme-scpl.scss
+++ b/_sass/jekyll-theme-scpl.scss
@@ -412,3 +412,9 @@ iframe {
 	width: 100%;
 	height: 300px;
 }
+
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #29374c;
+	}
+}


### PR DESCRIPTION
This adds a dark theme that is enabled automatically with the CSS media feature, [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).

![Dark theme example](https://user-images.githubusercontent.com/24855774/59879519-e3e05800-9378-11e9-8a03-91de0230d201.png)